### PR TITLE
Remove redundant dependencies from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source "http://rubygems.org"
 
 gemspec
-gem 'rake'
-gem 'rspec'
-gem 'rack-test'
 gem "r509", :git => "git://github.com/reaperhulk/r509.git"
 #gem "r509-middleware-validity", :git => "git://github.com/sirsean/r509-middleware-validity.git"
 #gem "r509-middleware-certwriter", :git => "git://github.com/sirsean/r509-middleware-certwriter.git"


### PR DESCRIPTION
This change removes the bundler warnings "Your Gemfile lists the gem ... more than once."
