### PR TITLE
Validity period param is in seconds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Required POST parameters:
 
 - ca
 - profile
-- validityPeriod (in days)
+- validityPeriod (in seconds)
 - csr (or spki)
 - subject
 

--- a/lib/r509/certificateauthority/http/validityperiodconverter.rb
+++ b/lib/r509/certificateauthority/http/validityperiodconverter.rb
@@ -8,7 +8,10 @@ module R509::CertificateAuthority::HTTP
         raise ArgumentError, "Validity period must be positive"
       end
       {
-        :not_before => Time.now - 6 * 60 * 60,
+        # Begin the validity period 6 hours into the past, to account for
+        # possibly-slow clocks.
+        :not_before => Time.now - (6 * 60 * 60),
+        # Add validity_period number of seconds to the current time.
         :not_after => Time.now + validity_period.to_i,
       }
     end


### PR DESCRIPTION
Make this clear in the ValidityPeriodConverter helper, and update the
README to reflect the correct units.
