### PR TITLE
Move loading/printing of config out of config.ru and support reload via USR2

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ For that, we've created a few pieces of Rack middleware for your use.
 
 After installing one or both of them, you'll have to edit your ```config.ru`` and/or ```config.yaml``` files.
 
+##Signals
+
+You can send a kill -USR2 signal to any running r509-ca-http process to cause it to reload and print its config to the logs (provided your app server isn't trapping USR2 first).
+
 ##Support
 
 You can file bugs on GitHub or join the #r509 channel on irc.freenode.net to ask questions.

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,7 @@
 require 'r509'
 require 'dependo'
 require 'logger'
+require 'r509/certificateauthority/http/server'
 
 Dependo::Registry[:log] = Logger.new(STDOUT)
 
@@ -20,21 +21,9 @@ begin
 rescue Gem::LoadError
 end
 
-config_data = File.read("config.yaml")
+R509::CertificateAuthority::HTTP::Config.load_config
 
-Dependo::Registry[:config_pool] = R509::Config::CAConfigPool.from_yaml("certificate_authorities", config_data)
-
-require 'r509/certificateauthority/http/server'
-
-Dependo::Registry[:config_pool].all.each do |config|
-  Dependo::Registry[:log].info "Config: "
-  Dependo::Registry[:log].info "CA Cert:"+config.ca_cert.subject.to_s
-  Dependo::Registry[:log].info "OCSP Cert (may be the same as above):"+config.ocsp_cert.subject.to_s
-  Dependo::Registry[:log].info "OCSP Validity Hours: "+config.ocsp_validity_hours.to_s
-  Dependo::Registry[:log].info "CRL Validity Hours: "+config.crl_validity_hours.to_s
-  Dependo::Registry[:log].info "\n"
-end
+R509::CertificateAuthority::HTTP::Config.print_config
 
 server = R509::CertificateAuthority::HTTP::Server
-
 run server

--- a/lib/r509/certificateauthority/http/config.rb
+++ b/lib/r509/certificateauthority/http/config.rb
@@ -1,0 +1,21 @@
+module R509::CertificateAuthority::HTTP
+  class Config
+    def self.load_config
+      config_data = File.read("config.yaml")
+
+      Dependo::Registry[:config_pool] = R509::Config::CAConfigPool.from_yaml("certificate_authorities", config_data)
+    end
+
+    def self.print_config
+      Dependo::Registry[:log].warn "Config loaded"
+      Dependo::Registry[:config_pool].all.each do |config|
+        Dependo::Registry[:log].warn "Config: "
+        Dependo::Registry[:log].warn "CA Cert:"+config.ca_cert.subject.to_s
+        Dependo::Registry[:log].warn "OCSP Cert (may be the same as above):"+config.ocsp_cert.subject.to_s
+        Dependo::Registry[:log].warn "OCSP Validity Hours: "+config.ocsp_validity_hours.to_s
+        Dependo::Registry[:log].warn "CRL Validity Hours: "+config.crl_validity_hours.to_s
+        Dependo::Registry[:log].warn "\n"
+      end
+    end
+  end
+end

--- a/lib/r509/certificateauthority/http/server.rb
+++ b/lib/r509/certificateauthority/http/server.rb
@@ -1,5 +1,6 @@
 require 'sinatra/base'
 require 'r509'
+require "#{File.dirname(__FILE__)}/config"
 require "#{File.dirname(__FILE__)}/subjectparser"
 require "#{File.dirname(__FILE__)}/validityperiodconverter"
 require "#{File.dirname(__FILE__)}/factory"
@@ -7,6 +8,14 @@ require 'base64'
 require 'yaml'
 require 'logger'
 require 'dependo'
+
+# Capture USR2 calls so we can reload and print the config
+# I'd rather use HUP, but daemons like thin already capture that
+# so we can't use it.
+Signal.trap("USR2") do
+  R509::CertificateAuthority::HTTP::Config.load_config
+  R509::CertificateAuthority::HTTP::Config.print_config
+end
 
 module R509
   module CertificateAuthority


### PR DESCRIPTION
Same as r509-ocsp-responder, move the loading/printing of the config out of config.ru and into a newly created R509::CertificateAuthority::HTTP::Config class.

Trap the USR2 signal to reload the config.

Fixes #11.
